### PR TITLE
Streamline

### DIFF
--- a/interactive_visualization/server.R
+++ b/interactive_visualization/server.R
@@ -245,171 +245,6 @@ observe({
 
 
 
-  ### update tax brackets based on previous decisions
-  #observeEvent(input$submit,priority=1,{
-observe({
-    val <- bracketVal1T()
-    # val2 <- bracketVal2() ## avoid switching back and forth
-    val2 <- as.numeric(input$bracketV2T)
-    if(is.na(val2) | is.na(val)){
-      
-    }else if(val>val2){
-      updateTextInput(session, "bracketV2T",value=val+10)
-    }
-    #updateNumericInput( session = session, inputId = 'refresh_helper', value = input$refresh_helper + 1 )
-    
-    
-  })
-
-  observe({
-    val <- bracketVal2T()
-    # val2 <- bracketVal3() ## avoid switching back and forth
-    val2 <- as.numeric(input$bracketV3T)
-    if(is.na(val2) | is.na(val)){
-      
-    }else if(val>val2)
-    updateTextInput(session, "bracketV3T",value=val+10)
-    
-  })
-
-  observe({
-    val <- bracketVal3T()
-    # val2 <- bracketVal4() ## avoid switching back and forth
-    val2 <- as.numeric(input$bracketV4T)
-    if(is.na(val2) | is.na(val)){
-      
-    }else if(val>val2)
-    updateTextInput(session, "bracketV4T",value=val+10)
-    
-  })
-
-  observe({
-    #if (input$extraBrackets>=1) {    
-    if(!is.null(input$bracketV5T) ){
-
-      val <- bracketVal4T()
-      val2 <- as.numeric(input$bracketV5T)
-      if(is.na(val2) | is.na(val)){
-        
-      }else if(val>val2)
-        updateTextInput(session, "bracketV5T",value=val+10)
-      
-    }
-      
-    #}
-  })
-
-  observe({
-    #if (input$extraBrackets>=2) {
-    if(!is.null(input$bracketV5T) & !is.null(input$bracketV6T)){
-      val <- as.numeric(bracketVal5T())
-      val2 <- as.numeric(input$bracketV6T)
-      if(is.na(val2) | is.na(val)){
-        
-      }else if(val>val2)
-      updateTextInput(session, "bracketV6T",value=val+10)
-    
-    }
-   # }
-  })
-
-  observe({
-    #if (input$extraBrackets>=3) {
-    if(!is.null(input$bracketV6T) & !is.null(input$bracketV7T)){
-      
-      val <- as.numeric(bracketVal6T())
-      val2 <- as.numeric(input$bracketV7T)
-      if(is.na(val2) | is.na(val)){
-        
-      }else if(val>val2)
-        updateTextInput(session, "bracketV7T",value=val+10)
-    }
-    #}
-  })
-
-  observe({
-    #if (input$extraBrackets>=4) {
-    if(!is.null(input$bracketV7T) & !is.null(input$bracketV8T)){
-      
-      val <- as.numeric(bracketVal7T())
-      val2 <- as.numeric(input$bracketV8T)
-      if(is.na(val2) | is.na(val)){
-        
-      }else if(val>val2)
-        updateTextInput(session, "bracketV8T",value=val+10)
-    }
-    #}
-  })
-
-  ###
-
-  ### marginal tax rate only increasing
-  observe({
-    if (bracket2T() < bracket1T()) {
-      updateTextInput(session, "bracket2T",value=bracket1T())
-    }
-  })
-
-  observe({
-    if (bracket3T() < bracket2T()) {
-      updateTextInput(session, "bracket3T",value=bracket2T())
-      
-    }
-  })
-
-  observe({
-    if (bracket4T() < bracket3T()) {
-      updateTextInput(session, "bracket4T",value=bracket3T())
-      
-    }
-  })
-
-  observe({
-  if (input$extraBrackets>=5) {
-    #browser()
-    if(!is.null(input$bracket5T)){
-    #delay(10)
-      if (bracket5T() < bracket4T()) {
-        updateTextInput(session, "bracket5T",value=bracket4T())
-
-      }
-    }
-    }
-  })
-
-  observe({
-    if (input$extraBrackets>=6) {
-      if(!is.null(input$bracket6T)){
-      if (bracket6T() < bracket5T()) {
-        updateTextInput(session, "bracket6T",value=bracket5T())
-
-      }
-      }
-    }
-  })
-
-  observe({
-    if (input$extraBrackets>=7) {
-      if(!is.null(input$bracket7T)){
-      if (bracket7T() < bracket6T()) {
-        updateTextInput(session, "bracket7T",value=bracket6T())
-
-      }
-      }
-    }
-  })
-
-  observe({
-    if (input$extraBrackets>=8) {
-      if(!is.null(input$bracket8T)){
-      if (bracket8T() < bracket7T()) {
-        updateTextInput(session, "bracket8T",value=bracket7T())
-
-      }
-      }
-    }
-  })
-  
   observe({
     if(input$evasion!=""){
     if(as.numeric(input$evasion)<0){
@@ -502,9 +337,9 @@ observe({
     
   })
   
-  ## don't let  tax brackets go below 1 million or above max wealth after evasion
+  ## don't let  tax brackets go below 0 or above max wealth after evasion
   observe({
-    if(  bracketVal1T()<1){
+    if(  bracketVal1T()<0){
       updateTextInput(session, "bracketV1T",value=1)
       
     }
@@ -520,7 +355,7 @@ observe({
   })
   
   observe({
-    if(bracketVal2T()<1){
+    if(bracketVal2T()<0){
       updateTextInput(session, "bracketV2T",value=1)
       
     }
@@ -535,7 +370,7 @@ observe({
     
   })
   observe({
-    if(bracketVal3T()<1){
+    if(bracketVal3T()<0){
       updateTextInput(session, "bracketV3T",value=1)
       
     }
@@ -551,7 +386,7 @@ observe({
   })
   
   observe({
-    if(bracketVal4T()<1){
+    if(bracketVal4T()<0){
       updateTextInput(session, "bracketV4T",value=1)
       
     }
@@ -569,7 +404,7 @@ observe({
   observe({
     if (input$extraBrackets>=5) {
       if(!is.null(input$bracketV5T)){
-        if(bracketVal5T()<1){
+        if(bracketVal5T()<0){
           updateTextInput(session, "bracketV5T",value=1)
           
         }
@@ -591,7 +426,7 @@ observe({
   observe({
     if (input$extraBrackets>=6) {
       if(!is.null(input$bracketV6T)){
-        if(bracketVal6T()<1){
+        if(bracketVal6T()<0){
           updateTextInput(session, "bracketV6T",value=1)
           
         }
@@ -613,7 +448,7 @@ observe({
   observe({
     if (input$extraBrackets>=7) {
       if(!is.null(input$bracketV7T)){
-        if(bracketVal7T()<1){
+        if(bracketVal7T()<0){
           updateTextInput(session, "bracketV7T",value=1)
           
         }
@@ -635,7 +470,7 @@ observe({
   observe({
     if (input$extraBrackets>=8) {
       if(!is.null(input$bracketV8T)){
-        if(bracketVal8T()<1){
+        if(bracketVal8T()<0){
           updateTextInput(session, "bracketV8T",value=1)
           
         }
@@ -751,38 +586,55 @@ observe({
       taxRate <- c(taxRate, as.numeric(input$bracket5T), as.numeric(input$bracket6T), as.numeric(input$bracket7T), as.numeric(input$bracket8T))
     }
 
-
+    brackets <- as.numeric(c(bracketVal1T(), bracketVal2T(), bracketVal3T(), bracketVal4T()))
+    if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
+      brackets <- c(brackets, as.numeric(input$bracketV5T))
+    }
+    if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
+      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T))
+    }
+    if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
+      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T),as.numeric(input$bracketV7T))
+    }
+    if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
+      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T),as.numeric(input$bracketV7T), as.numeric(input$bracketV8T))
+    }
+    
+    reorderIdx=order(as.numeric(brackets))
+    brackets = brackets[reorderIdx]
+    taxRate=taxRate[reorderIdx]
+#browser()
     xval <- 10^seq(log10(1e6), log10(45e9), by = 0.001) ## get uniform on log scale
 
-idx0 <- xval <= as.numeric(bracketVal1T())*1e6
-    idx1 <- xval <= as.numeric(bracketVal2T()) * 1e6 & xval > as.numeric(bracketVal1T())*1e6
-    idx2 <- xval > as.numeric(bracketVal2T()) * 1e6 & xval <= as.numeric(bracketVal3T()) * 1e6
-    idx3 <- xval > as.numeric(bracketVal3T()) * 1e6 & xval <= as.numeric(bracketVal4T()) * 1e6
+idx0 <- xval <= as.numeric(brackets[1])*1e6
+    idx1 <- xval <= as.numeric(brackets[2]) * 1e6 & xval > as.numeric(brackets[1])*1e6
+    idx2 <- xval > as.numeric(brackets[2]) * 1e6 & xval <= as.numeric(brackets[3]) * 1e6
+    idx3 <- xval > as.numeric(brackets[3]) * 1e6 & xval <= as.numeric(brackets[4]) * 1e6
 
     if (input$extraBrackets==8 & !is.null(input$bracket8T)) { ## since nested, test this one first
-      idx4 <- xval > as.numeric(bracketVal4T()) * 1e6 & xval <= as.numeric(input$bracketV5T) * 1e6
-      idx5 <- xval > as.numeric(input$bracketV5T) * 1e6 & xval <= as.numeric(input$bracketV6T) * 1e6
-      idx6 <- xval > as.numeric(input$bracketV6T) * 1e6 & xval <= as.numeric(input$bracketV7T) * 1e6
-      idx7 <- xval > as.numeric(input$bracketV7T) * 1e6 & xval <= as.numeric(input$bracketV8T) * 1e6
-      idx8 <- xval > as.numeric(input$bracketV8T)
+      idx4 <- xval > as.numeric(brackets[4]) * 1e6 & xval <= as.numeric(brackets[5]) * 1e6
+      idx5 <- xval > as.numeric(brackets[5]) * 1e6 & xval <= as.numeric(brackets[6]) * 1e6
+      idx6 <- xval > as.numeric(brackets[6]) * 1e6 & xval <= as.numeric(brackets[7]) * 1e6
+      idx7 <- xval > as.numeric(brackets[7]) * 1e6 & xval <= as.numeric(brackets[8]) * 1e6
+      idx8 <- xval > as.numeric(brackets[8])
       idx <- cbind.data.frame(idx0,idx1, idx2, idx3, idx4, idx5, idx6, idx7, idx8)
     } else if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
-      idx4 <- xval > as.numeric(bracketVal4T()) * 1e6 & xval <= as.numeric(input$bracketV5T) * 1e6
-      idx5 <- xval > as.numeric(input$bracketV5T) * 1e6 & xval <= as.numeric(input$bracketV6T) * 1e6
-      idx6 <- xval > as.numeric(input$bracketV6T) * 1e6 & xval <= as.numeric(input$bracketV7T) * 1e6
-      idx7 <- xval > as.numeric(input$bracketV7T) * 1e6
+      idx4 <- xval > as.numeric(brackets[4]) * 1e6 & xval <= as.numeric(brackets[5]) * 1e6
+      idx5 <- xval > as.numeric(brackets[5]) * 1e6 & xval <= as.numeric(brackets[6]) * 1e6
+      idx6 <- xval > as.numeric(brackets[6]) * 1e6 & xval <= as.numeric(brackets[7]) * 1e6
+      idx7 <- xval > as.numeric(brackets[7]) * 1e6
       idx <- cbind.data.frame(idx0,idx1, idx2, idx3, idx4, idx5, idx6, idx7)
     } else if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
-      idx4 <- xval > as.numeric(bracketVal4T()) * 1e6 & xval <= as.numeric(input$bracketV5T) * 1e6
-      idx5 <- xval > as.numeric(input$bracketV5T) * 1e6 & xval <= as.numeric(input$bracketV6T) * 1e6
-      idx6 <- xval > as.numeric(input$bracketV6T) * 1e6
+      idx4 <- xval > as.numeric(brackets[4]) * 1e6 & xval <= as.numeric(brackets[5]) * 1e6
+      idx5 <- xval > as.numeric(brackets[5]) * 1e6 & xval <= as.numeric(brackets[6]) * 1e6
+      idx6 <- xval > as.numeric(brackets[6]) * 1e6
       idx <- cbind.data.frame(idx0,idx1, idx2, idx3, idx4, idx5, idx6)
     } else if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
-      idx4 <- xval > as.numeric(bracketVal4T()) * 1e6 & xval <= as.numeric(input$bracketV5T) * 1e6
-      idx5 <- xval > as.numeric(input$bracketV5T) * 1e6
+      idx4 <- xval > as.numeric(brackets[4]) * 1e6 & xval <= as.numeric(brackets[5]) * 1e6
+      idx5 <- xval > as.numeric(brackets[5]) * 1e6
       idx <- cbind.data.frame(idx0,idx1, idx2, idx3, idx4, idx5)
     } else {
-      idx4 <- xval > as.numeric(bracketVal4T()) * 1e6
+      idx4 <- xval > as.numeric(brackets[4]) * 1e6
       idx <- cbind.data.frame(idx0,idx1, idx2, idx3, idx4)
     }
 
@@ -801,19 +653,7 @@ idx0 <- xval <= as.numeric(bracketVal1T())*1e6
 
     toPlot2 <- merge(toPlot, toMatch, by.x = "getGroup", by.y = "group")
 
-    brackets <- as.numeric(c(bracketVal1T(), bracketVal2T(), bracketVal3T(), bracketVal4T()))
-    if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
-      brackets <- c(brackets, as.numeric(input$bracketV5T))
-    }
-    if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
-      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T))
-    }
-    if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
-      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T),as.numeric(input$bracketV7T))
-    }
-    if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
-      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T),as.numeric(input$bracketV7T), as.numeric(input$bracketV8T))
-    }
+    
 
 
     # unaffected by new grouping
@@ -821,7 +661,9 @@ idx0 <- xval <= as.numeric(bracketVal1T())*1e6
 
     toPlot2$marginalRate <- (toPlot2$marginalInt / toPlot2$xval) * 100
 
+#browser()
 
+head(toPlot2)
     toPlot2$id <- 1:nrow(toPlot2)
 
     toPlot2
@@ -929,6 +771,10 @@ idx0 <- xval <= as.numeric(bracketVal1T())*1e6
       if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
         bracketStarts <- c(bracketStarts, 1e6 * as.numeric(input$bracketV5T), 1e6 * as.numeric(input$bracketV6T),1e6 * as.numeric(input$bracketV7T),1e6 * as.numeric(input$bracketV8T))
       }
+      
+      reorderIdx=order(as.numeric(bracketStarts))
+      bracketStarts = bracketStarts[reorderIdx]
+      taxRate=taxRate[reorderIdx]
     
     taxPerBracket <- getTaxBasePerBracket(updateGrid(), as.numeric(taxRate),as.numeric(bracketStarts))
    
@@ -983,6 +829,10 @@ taxPerBracket/1e9 ## in billions
       if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
         bracketStarts <- c(bracketStarts, 1e6 * as.numeric(input$bracketV5T),1e6 * as.numeric(input$bracketV6T), 1e6 * as.numeric(input$bracketV7T), 1e6 * as.numeric(input$bracketV8T))
       }
+      
+      reorderIdx=order(as.numeric(bracketStarts))
+      bracketStarts = bracketStarts[reorderIdx]
+      taxRate=taxRate[reorderIdx]
     
     peoplePerBracket <- getPeoplePerBracket(updateGrid(), bracketStarts)
     numberTaxpayers <- peoplePerBracket$totalPeople
@@ -1037,42 +887,62 @@ taxPerBracket/1e9 ## in billions
       if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
         taxRate <- c(taxRate, as.numeric(input$bracket5T), as.numeric(input$bracket6T),as.numeric(input$bracket7T),as.numeric(input$bracket8T))
       }
-
-      # These are mini data set that ggvis needs to create vertical lines
-      extra0 <- cbind.data.frame(x = rep(as.numeric(bracketVal1T()) * 1e6, 2), y = c(0, taxRate[1]))
-      extra1 <- cbind.data.frame(x = rep(as.numeric(bracketVal2T()) * 1e6, 2), y = c(0, taxRate[1]))
-      extra1b <- cbind.data.frame(x = rep(as.numeric(bracketVal2T()) * 1e6, 2), y = c(0, taxRate[2]))
-      extra2 <- cbind.data.frame(x = rep(as.numeric(bracketVal3T()) * 1e6, 2), y = c(0, taxRate[2]))
-      extra2b <- cbind.data.frame(x = rep(as.numeric(bracketVal3T()) * 1e6, 2), y = c(0, taxRate[3]))
-      extra3 <- cbind.data.frame(x = rep(as.numeric(bracketVal4T()) * 1e6, 2), y = c(0, taxRate[3]))
-      extra3b <- cbind.data.frame(x = rep(as.numeric(bracketVal4T()) * 1e6, 2), y = c(0, taxRate[4]))
+      
+      brackets <- as.numeric(c(bracketVal1T(), bracketVal2T(), bracketVal3T(), bracketVal4T()))
       if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
-        extra4 <- cbind.data.frame(x = rep(as.numeric(input$bracketV5T) * 1e6, 2), y = c(0, taxRate[4]))
-        extra4b <- cbind.data.frame(x = rep(as.numeric(input$bracketV5T) * 1e6, 2), y = c(0, taxRate[5]))
+        brackets <- c(brackets, as.numeric(input$bracketV5T))
       }
       if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
-        extra4 <- cbind.data.frame(x = rep(as.numeric(input$bracketV5T) * 1e6, 2), y = c(0, taxRate[4]))
-        extra4b <- cbind.data.frame(x = rep(as.numeric(input$bracketV5T) * 1e6, 2), y = c(0, taxRate[5]))
-        extra5 <- cbind.data.frame(x = rep(as.numeric(input$bracketV6T) * 1e6, 2), y = c(0, taxRate[5]))
-        extra5b <- cbind.data.frame(x = rep(as.numeric(input$bracketV6T) * 1e6, 2), y = c(0, taxRate[6]))
+        brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T))
       }
       if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
-        extra4 <- cbind.data.frame(x = rep(as.numeric(input$bracketV5T) * 1e6, 2), y = c(0, taxRate[4]))
-        extra4b <- cbind.data.frame(x = rep(as.numeric(input$bracketV5T) * 1e6, 2), y = c(0, taxRate[5]))
-        extra5 <- cbind.data.frame(x = rep(as.numeric(input$bracketV6T) * 1e6, 2), y = c(0, taxRate[5]))
-        extra5b <- cbind.data.frame(x = rep(as.numeric(input$bracketV6T) * 1e6, 2), y = c(0, taxRate[6]))
-        extra6 <- cbind.data.frame(x = rep(as.numeric(input$bracketV7T) * 1e6, 2), y = c(0, taxRate[6]))
-        extra6b <- cbind.data.frame(x = rep(as.numeric(input$bracketV7T) * 1e6, 2), y = c(0, taxRate[7]))
+        brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T),as.numeric(input$bracketV7T))
       }
       if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
-        extra4 <- cbind.data.frame(x = rep(as.numeric(input$bracketV5T) * 1e6, 2), y = c(0, taxRate[4]))
-        extra4b <- cbind.data.frame(x = rep(as.numeric(input$bracketV5T) * 1e6, 2), y = c(0, taxRate[5]))
-        extra5 <- cbind.data.frame(x = rep(as.numeric(input$bracketV6T) * 1e6, 2), y = c(0, taxRate[5]))
-        extra5b <- cbind.data.frame(x = rep(as.numeric(input$bracketV6T) * 1e6, 2), y = c(0, taxRate[6]))
-        extra6 <- cbind.data.frame(x = rep(as.numeric(input$bracketV7T) * 1e6, 2), y = c(0, taxRate[6]))
-        extra6b <- cbind.data.frame(x = rep(as.numeric(input$bracketV7T) * 1e6, 2), y = c(0, taxRate[7]))
-        extra7 <- cbind.data.frame(x = rep(as.numeric(input$bracket8T) * 1e6, 2), y = c(0, taxRate[7]))
-        extra7b <- cbind.data.frame(x = rep(as.numeric(input$bracketV8T) * 1e6, 2), y = c(0, taxRate[8]))
+        brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T),as.numeric(input$bracketV7T), as.numeric(input$bracketV8T))
+      }
+      
+
+      #browser()
+      reorderIdx=order(as.numeric(brackets))
+      brackets = brackets[reorderIdx]
+      taxRate=taxRate[reorderIdx]
+      
+      # These are mini data set that ggvis needs to create vertical lines
+      extra0 <- cbind.data.frame(x = rep(as.numeric(brackets[1]) * 1e6, 2), y = c(0, taxRate[1]))
+      extra1 <- cbind.data.frame(x = rep(as.numeric(brackets[2]) * 1e6, 2), y = c(0, taxRate[1]))
+      extra1b <- cbind.data.frame(x = rep(as.numeric(brackets[2]) * 1e6, 2), y = c(0, taxRate[2]))
+      extra2 <- cbind.data.frame(x = rep(as.numeric(brackets[3]) * 1e6, 2), y = c(0, taxRate[2]))
+      extra2b <- cbind.data.frame(x = rep(as.numeric(brackets[3]) * 1e6, 2), y = c(0, taxRate[3]))
+      extra3 <- cbind.data.frame(x = rep(as.numeric(brackets[4]) * 1e6, 2), y = c(0, taxRate[3]))
+      extra3b <- cbind.data.frame(x = rep(as.numeric(brackets[4]) * 1e6, 2), y = c(0, taxRate[4]))
+      if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
+        extra4 <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[4]))
+        extra4b <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[5]))
+      }
+      if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
+        extra4 <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[4]))
+        extra4b <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[5]))
+        extra5 <- cbind.data.frame(x = rep(as.numeric(brackets[6]) * 1e6, 2), y = c(0, taxRate[5]))
+        extra5b <- cbind.data.frame(x = rep(as.numeric(brackets[6]) * 1e6, 2), y = c(0, taxRate[6]))
+      }
+      if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
+        extra4 <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[4]))
+        extra4b <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[5]))
+        extra5 <- cbind.data.frame(x = rep(as.numeric(brackets[6]) * 1e6, 2), y = c(0, taxRate[5]))
+        extra5b <- cbind.data.frame(x = rep(as.numeric(brackets[6]) * 1e6, 2), y = c(0, taxRate[6]))
+        extra6 <- cbind.data.frame(x = rep(as.numeric(brackets[7]) * 1e6, 2), y = c(0, taxRate[6]))
+        extra6b <- cbind.data.frame(x = rep(as.numeric(brackets[7]) * 1e6, 2), y = c(0, taxRate[7]))
+      }
+      if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
+        extra4 <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[4]))
+        extra4b <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[5]))
+        extra5 <- cbind.data.frame(x = rep(as.numeric(brackets[6]) * 1e6, 2), y = c(0, taxRate[5]))
+        extra5b <- cbind.data.frame(x = rep(as.numeric(brackets[6]) * 1e6, 2), y = c(0, taxRate[6]))
+        extra6 <- cbind.data.frame(x = rep(as.numeric(brackets[7]) * 1e6, 2), y = c(0, taxRate[6]))
+        extra6b <- cbind.data.frame(x = rep(as.numeric(brackets[7]) * 1e6, 2), y = c(0, taxRate[7]))
+        extra7 <- cbind.data.frame(x = rep(as.numeric(brackets[8]) * 1e6, 2), y = c(0, taxRate[7]))
+        extra7b <- cbind.data.frame(x = rep(as.numeric(brackets[8]) * 1e6, 2), y = c(0, taxRate[8]))
       }
     
 
@@ -1099,19 +969,6 @@ taxPerBracket/1e9 ## in billions
     
       data <- dataInputT()
 
-      brackets <- as.numeric(c(bracketVal1T(), bracketVal2T(), bracketVal3T(), bracketVal4T()))
-      if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
-        brackets <- c(brackets, as.numeric(input$bracketV5T))
-      }
-      if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
-        brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T))
-      }
-      if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
-        brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T),as.numeric(input$bracketV7T))
-      }
-      if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
-        brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T),as.numeric(input$bracketV7T), as.numeric(input$bracketV8T))
-      }
       
 
     rmIdx <- ncol(data)

--- a/interactive_visualization/server.R
+++ b/interactive_visualization/server.R
@@ -1,133 +1,114 @@
 
 server <- function(input, output, session) {
-  
-  observeEvent(input$reset,{
-    click("submit")
+
+  ## reset everything when you click rese
+  observeEvent(input$reset, {
     reset("extraBrackets")
     reset("evasion")
     reset("bracket1T")
     reset("bracket2T")
     reset("bracket3T")
     reset("bracket4T")
-    ## not necessary if change extraBrackets back to zero?
-    # reset("bracket5T")
-    # reset("bracket6T")
-    # reset("bracket7T")
-    # reset("bracket8T")
-    
+
+
     reset("bracketV1T")
     reset("bracketV2T")
     reset("bracketV3T")
     reset("bracketV4T")
-    # reset("bracketV5T")
-    # reset("bracketV6T")
-    # reset("bracketV7T")
-    # reset("bracketV8T")
-    
 
+
+    click("submit") ## Not working
   })
-  
-  ##https://stackoverflow.com/questions/39627760/conditional-panel-in-shiny-doesnt-update-variables
-  output$myui <- renderUI({
-    if(input$extraBrackets == 5){
-      textInput("bracket5T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3")
-      
 
-    }else if(input$extraBrackets ==6){
+  ## https://stackoverflow.com/questions/39627760/conditional-panel-in-shiny-doesnt-update-variables
+
+  ## add brackets - tax rate
+  output$myui <- renderUI({
+    if (input$extraBrackets == 5) {
+      textInput("bracket5T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3")
+    } else if (input$extraBrackets == 6) {
       tagList(
-      textInput("bracket5T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3"),
-      
-      textInput("bracket6T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3")
+        textInput("bracket5T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3"),
+
+        textInput("bracket6T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3")
       )
-      
-    }else if(input$extraBrackets ==7){
+    } else if (input$extraBrackets == 7) {
       tagList(
-      textInput("bracket5T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3"),
-      
-      textInput("bracket6T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3"),
-      textInput("bracket7T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3")
+        textInput("bracket5T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3"),
+
+        textInput("bracket6T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3"),
+        textInput("bracket7T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3")
       )
-      
-    }else if(input$extraBrackets==8){
+    } else if (input$extraBrackets == 8) {
       tagList(
-      textInput("bracket5T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3"),
-      
-      textInput("bracket6T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3"),
-      textInput("bracket7T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3"),
-      textInput("bracket8T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3")
+        textInput("bracket5T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3"),
+
+        textInput("bracket6T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3"),
+        textInput("bracket7T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3"),
+        textInput("bracket8T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3")
       )
-      
     }
   })
-  
+
+  ## add brackets - value
   output$myui2 <- renderUI({
-    if(input$extraBrackets == 5){
+    if (input$extraBrackets == 5) {
       textInput("bracketV5T", label = "to wealth above ($m):", value = "1500")
-      
-      
-    }else if(input$extraBrackets ==6){
+    } else if (input$extraBrackets == 6) {
       tagList(
         textInput("bracketV5T", label = "to wealth above ($m):", value = "1500"),
-        
-        
+
+
         textInput("bracketV6T", label = "to wealth above ($m):", value = "1600")
-        
       )
-      
-    }else if(input$extraBrackets ==7){
+    } else if (input$extraBrackets == 7) {
       tagList(
         textInput("bracketV5T", label = "to wealth above ($m):", value = "1500"),
-        
-        
+
+
         textInput("bracketV6T", label = "to wealth above ($m):", value = "1600"),
         textInput("bracketV7T", label = "to wealth above ($m):", value = "1700")
       )
-      
-    }else if(input$extraBrackets==8){
+    } else if (input$extraBrackets == 8) {
       tagList(
         textInput("bracketV5T", label = "to wealth above ($m):", value = "1500"),
-        
-        
+
+
         textInput("bracketV6T", label = "to wealth above ($m):", value = "1600"),
         textInput("bracketV7T", label = "to wealth above ($m):", value = "1700"),
         textInput("bracketV8T", label = "to wealth above ($m):", value = "1900")
-        
       )
-      
     }
   })
 
   grid <- read.csv("taxBaseGridUpdated.csv")
-  
- updateGrid <-reactive({
-    grid$thresNew <- (1 - as.numeric(input$evasion)/100) * grid$thres 
-    grid$avgNew <- (1-as.numeric(input$evasion)/100)*grid$avg ## 
-return(grid)
+
+  ## update data with evasion parameter
+  updateGrid <- reactive({
+    grid$thresNew <- (1 - as.numeric(input$evasion) / 100) * grid$thres
+    grid$avgNew <- (1 - as.numeric(input$evasion) / 100) * grid$avg ##
+    return(grid)
   })
- 
- getPercentile <- function(grid,value){
-   perc=grid$gperc[which.min(abs(grid$thresNew-value*1e6))]
-   return(format(round(100-perc,5),scientific = F))
- }
 
- 
-
-
-  getTaxBasePerBracket <- function(grid, taxLevels,brackets) {
-    ## brackets is lower end of each bracket
-
-   test =unlist(lapply(grid$avgNew,getAverageTax,taxLevels,brackets/1e6))
-    
-
-
-    return(sum(grid$nb*test))
+  ## get percentile for display
+  ## after evasion
+  getPercentile <- function(grid, value) {
+    perc <- grid$gperc[which.min(abs(grid$thresNew - value * 1e6))]
+    return(format(round(100 - perc, 5), scientific = F))
   }
 
+
+
+  ## gets taxes paid per bracket
+  getTaxBasePerBracket <- function(grid, taxLevels, brackets) {
+    test <- unlist(lapply(grid$avgNew, getAverageTax, taxLevels, brackets / 1e6))
+
+    return(sum(grid$nb * test))
+  }
+
+  ## gets people per bracket
   getPeoplePerBracket <- function(grid, brackets) {
-    #browser()
-    ## brackets is lower end of each bracket
     brackets <- c(brackets, max(grid$thresNew) + 1e6) ## get last bracket
-    #brackets <- c(brackets, 1e10+1e6)
     grid$group <- cut(grid$thresNew, brackets, include.lowest = T)
     toReturn <- grid %>% group_by(group) %>% summarise(totalPeople = sum(nb)) %>% drop_na() %>% complete(group, fill = list(totalPeople = 0)) ## avoid dropping levels without any people
 
@@ -137,363 +118,328 @@ return(grid)
   }
 
 
-  #https://github.com/rstudio/shiny/issues/1140
-observe({
-  updateTextInput(session, "bracketV1T",label =paste("to the top ",getPercentile(updateGrid(),bracketVal1T()),"%'s wealth above ($m):",sep="") )
-})
-
-observe({
-  updateTextInput(session, "bracketV2T",label = paste("to the top ",getPercentile(updateGrid(),bracketVal2T()),"%'s wealth above ($m):",sep=""))
-})
-
-observe({
-  updateTextInput(session, "bracketV3T",label = paste("to the top ",getPercentile(updateGrid(),bracketVal3T()),"%'s wealth above ($m):",sep=""))
-})
-
-observe({
-  updateTextInput(session, "bracketV4T",paste("to the top ",getPercentile(updateGrid(),bracketVal4T()),"%'s wealth above ($m):",sep=""))
-})
-
-observe({
-  if(input$extraBrackets>=5){
-    if(!is.null(input$bracketV5T)){
-  updateTextInput(session, "bracketV5T",label = paste("to the top ",getPercentile(updateGrid(),bracketVal5T()),"%'s wealth above ($m):",sep=""),value=bracketVal5T())
-    }
-  }
-})
-
-observe({
-  if(input$extraBrackets>=6){
-    if(!is.null(input$bracketV6T)){
-  updateTextInput(session, "bracketV6T",label = paste("to the top ",getPercentile(updateGrid(),bracketVal6T()),"%'s wealth above ($m):",sep=""),value=bracketVal6T())
-    }
-  }
-})
-
-observe({
-  if(input$extraBrackets>=7){
-    if(!is.null(input$bracketV7T)){
-  updateTextInput(session, "bracketV7T",label = paste("to the top ",getPercentile(updateGrid(),bracketVal7T()),"%'s wealth above ($m):",sep=""),value=bracketVal7T())
-    }
-  }
-})
-
-observe({
-  if(input$extraBrackets>=8){
-    if(!is.null(input$bracketV8T)){
-  updateTextInput(session, "bracketV8T",label = paste("to the top ",getPercentile(updateGrid(),bracketVal8T()),"%'s wealth above ($m):",sep=""),value=bracketVal8T())
-    }
-  }
-})
-
-
-observe({
-  if(bracketVal1T()==bracketVal2T()){
-    updateTextInput(session, "bracketV2T",label = paste("to the top ",getPercentile(updateGrid(),bracketVal1T()+10),"%'s wealth above ($m):",sep=""),value=bracketVal1T()+10)
-  }
-  
-})
-
-observe({
-  if(bracketVal2T()==bracketVal3T()){
-    updateTextInput(session, "bracketV3T",label = paste("to the top ",getPercentile(updateGrid(),bracketVal2T()+10),"%'s wealth above ($m):",sep=""),value=bracketVal2T()+10)
-  }
-  
-})
-
-observe({
- 
-  if(bracketVal3T()==bracketVal4T()){
-    updateTextInput(session, "bracketV4T",label = paste("to the top ",getPercentile(updateGrid(),bracketVal3T()+10),"%'s wealth above ($m):",sep=""),value=bracketVal3T()+10)
-  }
-  
-})
-
-## need an extra layer of protection here
-observe({
-  if(input$extraBrackets>=5){
-  if(!is.null(input$bracketV5T) & bracketVal4T()==bracketVal5T()){
-    updateTextInput(session, "bracketV5T",label = paste("to the top ",getPercentile(updateGrid(),bracketVal4T()+10),"%'s wealth above ($m):",sep=""),value=bracketVal4T()+10)
-  }
-  }
-})
-
-observe({
-  if(input$extraBrackets>=6){
-  if(!is.null(input$bracketV6T) & bracketVal5T()==bracketVal6T()){
-    updateTextInput(session, "bracketV6T",label = paste("to the top ",getPercentile(updateGrid(),bracketVal5T()+10),"%'s wealth above ($m):",sep=""),value=bracketVal5T()+10)
-  }
-  }
-})
-
-observe({
-  if(input$extraBrackets>=7){
-  if(!is.null(input$bracketV7T) & bracketVal6T()==bracketVal7T()){
-    updateTextInput(session, "bracketV7T",label = paste("to the top ",getPercentile(updateGrid(),bracketVal6T()+10),"%'s wealth above ($m):",sep=""),value=bracketVal6T()+10)
-  }
-  }
-})
-
-observe({
-  if(input$extraBrackets>=8){
-  if(!is.null(input$bracketV8T) & bracketVal7T()==bracketVal8T()){
-    updateTextInput(session, "bracketV8T",label = paste("to the top ",getPercentile(updateGrid(),bracketVal7T()+10),"%'s wealth above ($m):",sep=""),value=bracketVal7T()+10)
-  }
-  }
-})
-
-
-
-
-
+  # https://github.com/rstudio/shiny/issues/1140
+  ## update percentile for new bracket value
   observe({
-    if(input$evasion!=""){
-    if(as.numeric(input$evasion)<0){
-      updateTextInput(session, "evasion", value = "0")
-    }
-    }
+    updateTextInput(session, "bracketV1T", label = paste("to the top ", getPercentile(updateGrid(), bracketVal1T()), "%'s wealth above ($m):", sep = ""))
   })
-  
+
   observe({
-    if(input$evasion!=""){
-    if(as.numeric(input$evasion)>50){
-      updateTextInput(session, "evasion", value = "50")
-    }
+    updateTextInput(session, "bracketV2T", label = paste("to the top ", getPercentile(updateGrid(), bracketVal2T()), "%'s wealth above ($m):", sep = ""))
+  })
+
+  observe({
+    updateTextInput(session, "bracketV3T", label = paste("to the top ", getPercentile(updateGrid(), bracketVal3T()), "%'s wealth above ($m):", sep = ""))
+  })
+
+  observe({
+    updateTextInput(session, "bracketV4T", paste("to the top ", getPercentile(updateGrid(), bracketVal4T()), "%'s wealth above ($m):", sep = ""))
+  })
+
+  observe({
+    if (input$extraBrackets >= 5) {
+      if (!is.null(input$bracketV5T)) {
+        updateTextInput(session, "bracketV5T", label = paste("to the top ", getPercentile(updateGrid(), bracketVal5T()), "%'s wealth above ($m):", sep = ""), value = bracketVal5T())
+      }
     }
   })
 
-## don't let negative tax rates
   observe({
-    if(bracket1T()<0){
-      updateTextInput(session, "bracket1T",value=0)
-      
+    if (input$extraBrackets >= 6) {
+      if (!is.null(input$bracketV6T)) {
+        updateTextInput(session, "bracketV6T", label = paste("to the top ", getPercentile(updateGrid(), bracketVal6T()), "%'s wealth above ($m):", sep = ""), value = bracketVal6T())
+      }
     }
-    
   })
-  
+
   observe({
-    if(bracket2T()<0){
-      updateTextInput(session, "bracket2T",value=0)
-      
+    if (input$extraBrackets >= 7) {
+      if (!is.null(input$bracketV7T)) {
+        updateTextInput(session, "bracketV7T", label = paste("to the top ", getPercentile(updateGrid(), bracketVal7T()), "%'s wealth above ($m):", sep = ""), value = bracketVal7T())
+      }
     }
-    
   })
+
   observe({
-    if(bracket3T()<0){
-      updateTextInput(session, "bracket3T",value=0)
-      
+    if (input$extraBrackets >= 8) {
+      if (!is.null(input$bracketV8T)) {
+        updateTextInput(session, "bracketV8T", label = paste("to the top ", getPercentile(updateGrid(), bracketVal8T()), "%'s wealth above ($m):", sep = ""), value = bracketVal8T())
+      }
     }
-    
   })
-  
+
+  ## update if make two brackets the same
   observe({
-    if(bracket4T()<0){
-      updateTextInput(session, "bracket4T",value=0)
-      
+    if (bracketVal1T() == bracketVal2T()) {
+      updateTextInput(session, "bracketV2T", label = paste("to the top ", getPercentile(updateGrid(), bracketVal1T() + 10), "%'s wealth above ($m):", sep = ""), value = bracketVal1T() + 10)
     }
-    
   })
-  
+
   observe({
-    if (input$extraBrackets>=5) {
-      if(!is.null(input$bracket5T)){
-    if(bracket5T()<0){
-      updateTextInput(session, "bracket5T",value=0)
-      
+    if (bracketVal2T() == bracketVal3T()) {
+      updateTextInput(session, "bracketV3T", label = paste("to the top ", getPercentile(updateGrid(), bracketVal2T() + 10), "%'s wealth above ($m):", sep = ""), value = bracketVal2T() + 10)
     }
-      }}
-    
   })
-  
+
   observe({
-    if (input$extraBrackets>=6) {
-      if(!is.null(input$bracket6T)){
-        if(bracket6T()<0){
-          updateTextInput(session, "bracket6T",value=0)
-          
+    if (bracketVal3T() == bracketVal4T()) {
+      updateTextInput(session, "bracketV4T", label = paste("to the top ", getPercentile(updateGrid(), bracketVal3T() + 10), "%'s wealth above ($m):", sep = ""), value = bracketVal3T() + 10)
+    }
+  })
+
+  observe({
+    if (input$extraBrackets >= 5) {
+      if (!is.null(input$bracketV5T) & bracketVal4T() == bracketVal5T()) {
+        updateTextInput(session, "bracketV5T", label = paste("to the top ", getPercentile(updateGrid(), bracketVal4T() + 10), "%'s wealth above ($m):", sep = ""), value = bracketVal4T() + 10)
+      }
+    }
+  })
+
+  observe({
+    if (input$extraBrackets >= 6) {
+      if (!is.null(input$bracketV6T) & bracketVal5T() == bracketVal6T()) {
+        updateTextInput(session, "bracketV6T", label = paste("to the top ", getPercentile(updateGrid(), bracketVal5T() + 10), "%'s wealth above ($m):", sep = ""), value = bracketVal5T() + 10)
+      }
+    }
+  })
+
+  observe({
+    if (input$extraBrackets >= 7) {
+      if (!is.null(input$bracketV7T) & bracketVal6T() == bracketVal7T()) {
+        updateTextInput(session, "bracketV7T", label = paste("to the top ", getPercentile(updateGrid(), bracketVal6T() + 10), "%'s wealth above ($m):", sep = ""), value = bracketVal6T() + 10)
+      }
+    }
+  })
+
+  observe({
+    if (input$extraBrackets >= 8) {
+      if (!is.null(input$bracketV8T) & bracketVal7T() == bracketVal8T()) {
+        updateTextInput(session, "bracketV8T", label = paste("to the top ", getPercentile(updateGrid(), bracketVal7T() + 10), "%'s wealth above ($m):", sep = ""), value = bracketVal7T() + 10)
+      }
+    }
+  })
+
+
+
+
+  ## boundaries for evasion parameter
+  observe({
+    if (input$evasion != "") {
+      if (as.numeric(input$evasion) < 0) {
+        updateTextInput(session, "evasion", value = "0")
+      }
+    }
+  })
+
+  observe({
+    if (input$evasion != "") {
+      if (as.numeric(input$evasion) > 50) {
+        updateTextInput(session, "evasion", value = "50")
+      }
+    }
+  })
+
+  ## don't let negative tax rates
+  observe({
+    if (bracket1T() < 0) {
+      updateTextInput(session, "bracket1T", value = 0)
+    }
+  })
+
+  observe({
+    if (bracket2T() < 0) {
+      updateTextInput(session, "bracket2T", value = 0)
+    }
+  })
+  observe({
+    if (bracket3T() < 0) {
+      updateTextInput(session, "bracket3T", value = 0)
+    }
+  })
+
+  observe({
+    if (bracket4T() < 0) {
+      updateTextInput(session, "bracket4T", value = 0)
+    }
+  })
+
+  observe({
+    if (input$extraBrackets >= 5) {
+      if (!is.null(input$bracket5T)) {
+        if (bracket5T() < 0) {
+          updateTextInput(session, "bracket5T", value = 0)
         }
-      }}
-    
+      }
+    }
   })
-  
+
   observe({
-    if (input$extraBrackets>=7) {
-      if(!is.null(input$bracket7T)){
-        if(bracket7T()<0){
-          updateTextInput(session, "bracket7T",value=0)
-          
+    if (input$extraBrackets >= 6) {
+      if (!is.null(input$bracket6T)) {
+        if (bracket6T() < 0) {
+          updateTextInput(session, "bracket6T", value = 0)
         }
-      }}
-    
+      }
+    }
   })
-  
+
   observe({
-    if (input$extraBrackets>=8) {
-      if(!is.null(input$bracket8T)){
-        if(bracket8T()<0){
-          updateTextInput(session, "bracket8T",value=0)
-          
+    if (input$extraBrackets >= 7) {
+      if (!is.null(input$bracket7T)) {
+        if (bracket7T() < 0) {
+          updateTextInput(session, "bracket7T", value = 0)
         }
-      }}
-    
+      }
+    }
   })
-  
+
+  observe({
+    if (input$extraBrackets >= 8) {
+      if (!is.null(input$bracket8T)) {
+        if (bracket8T() < 0) {
+          updateTextInput(session, "bracket8T", value = 0)
+        }
+      }
+    }
+  })
+
   ## don't let  tax brackets go below 0 or above max wealth after evasion
   observe({
-    if(  bracketVal1T()<0){
-      updateTextInput(session, "bracketV1T",value=1)
-      
+    if (bracketVal1T() < 0) {
+      updateTextInput(session, "bracketV1T", value = 1)
     }
-    
-  })
-  
-  observe({
-    if(  bracketVal1T()>max( updateGrid()$thresNew)/1e6){
-      updateTextInput(session, "bracketV1T",value=round(max(updateGrid()$thresNew)/1e6,0))
-      print(max(updateGrid()$thresNew))
-    }
-    
-  })
-  
-  observe({
-    if(bracketVal2T()<0){
-      updateTextInput(session, "bracketV2T",value=1)
-      
-    }
-    
-    observe({
-      if(  bracketVal2T()>max( updateGrid()$thresNew)/1e6){
-        updateTextInput(session, "bracketV2T",value=round(max(updateGrid()$thresNew)/1e6,0))
-        print(max(updateGrid()$thresNew))
-      }
-      
-    })
-    
-  })
-  observe({
-    if(bracketVal3T()<0){
-      updateTextInput(session, "bracketV3T",value=1)
-      
-    }
-    
-  })
-  
-  observe({
-    if(  bracketVal3T()>max( updateGrid()$thresNew)/1e6){
-      updateTextInput(session, "bracketV3T",value=round(max(updateGrid()$thresNew)/1e6,0))
-      print(max(updateGrid()$thresNew))
-    }
-    
-  })
-  
-  observe({
-    if(bracketVal4T()<0){
-      updateTextInput(session, "bracketV4T",value=1)
-      
-    }
-    
-  })
-  
-  observe({
-    if(  bracketVal4T()>max( updateGrid()$thresNew)/1e6){
-      updateTextInput(session, "bracketV4T",value=round(max(updateGrid()$thresNew)/1e6,0))
-     # print(max(updateGrid()$thresNew))
-    }
-    
-  })
-  
-  observe({
-    if (input$extraBrackets>=5) {
-      if(!is.null(input$bracketV5T)){
-        if(bracketVal5T()<0){
-          updateTextInput(session, "bracketV5T",value=1)
-          
-        }
-      }}
-    
-  })
-  
-  observe({
-    if (input$extraBrackets>=5) {
-      if(!is.null(input$bracketV5T)){
-        if(bracketVal5T()>max( updateGrid()$thresNew)/1e6){
-          updateTextInput(session, "bracketV5T",value=round(max(updateGrid()$thresNew)/1e6,0))
-          
-        }
-      }}
-    
-  })
-  
-  observe({
-    if (input$extraBrackets>=6) {
-      if(!is.null(input$bracketV6T)){
-        if(bracketVal6T()<0){
-          updateTextInput(session, "bracketV6T",value=1)
-          
-        }
-      }}
-    
-  })
-  
-  observe({
-    if (input$extraBrackets>=6) {
-      if(!is.null(input$bracketV6T)){
-        if(bracketVal6T()>max( updateGrid()$thresNew)/1e6){
-          updateTextInput(session, "bracketV6T",value=round(max(updateGrid()$thresNew)/1e6,0))
-          
-        }
-      }}
-    
-  })
-  
-  observe({
-    if (input$extraBrackets>=7) {
-      if(!is.null(input$bracketV7T)){
-        if(bracketVal7T()<0){
-          updateTextInput(session, "bracketV7T",value=1)
-          
-        }
-      }}
-    
-  })
-  
-  observe({
-    if (input$extraBrackets>=7) {
-      if(!is.null(input$bracketV7T)){
-        if(bracketVal7T()>max( updateGrid()$thresNew)/1e6){
-          updateTextInput(session, "bracketV7T",value=round(max(updateGrid()$thresNew)/1e6,0))
-          
-        }
-      }}
-    
-  })
-  
-  observe({
-    if (input$extraBrackets>=8) {
-      if(!is.null(input$bracketV8T)){
-        if(bracketVal8T()<0){
-          updateTextInput(session, "bracketV8T",value=1)
-          
-        }
-      }}
-    
-  })
-  
-  observe({
-    if (input$extraBrackets>=8) {
-      if(!is.null(input$bracketV8T)){
-        if(bracketVal8T()>max( updateGrid()$thresNew)/1e6){
-          updateTextInput(session, "bracketV8T",value=round(max(updateGrid()$thresNew)/1e6,0))
-          
-        }
-      }}
-    
   })
 
+  observe({
+    if (bracketVal1T() > max(updateGrid()$thresNew) / 1e6) {
+      updateTextInput(session, "bracketV1T", value = round(max(updateGrid()$thresNew) / 1e6, 0))
+      print(max(updateGrid()$thresNew))
+    }
+  })
+
+  observe({
+    if (bracketVal2T() < 0) {
+      updateTextInput(session, "bracketV2T", value = 1)
+    }
+
+    observe({
+      if (bracketVal2T() > max(updateGrid()$thresNew) / 1e6) {
+        updateTextInput(session, "bracketV2T", value = round(max(updateGrid()$thresNew) / 1e6, 0))
+        print(max(updateGrid()$thresNew))
+      }
+    })
+  })
+  observe({
+    if (bracketVal3T() < 0) {
+      updateTextInput(session, "bracketV3T", value = 1)
+    }
+  })
+
+  observe({
+    if (bracketVal3T() > max(updateGrid()$thresNew) / 1e6) {
+      updateTextInput(session, "bracketV3T", value = round(max(updateGrid()$thresNew) / 1e6, 0))
+      print(max(updateGrid()$thresNew))
+    }
+  })
+
+  observe({
+    if (bracketVal4T() < 0) {
+      updateTextInput(session, "bracketV4T", value = 1)
+    }
+  })
+
+  observe({
+    if (bracketVal4T() > max(updateGrid()$thresNew) / 1e6) {
+      updateTextInput(session, "bracketV4T", value = round(max(updateGrid()$thresNew) / 1e6, 0))
+      # print(max(updateGrid()$thresNew))
+    }
+  })
+
+  observe({
+    if (input$extraBrackets >= 5) {
+      if (!is.null(input$bracketV5T)) {
+        if (bracketVal5T() < 0) {
+          updateTextInput(session, "bracketV5T", value = 1)
+        }
+      }
+    }
+  })
+
+  observe({
+    if (input$extraBrackets >= 5) {
+      if (!is.null(input$bracketV5T)) {
+        if (bracketVal5T() > max(updateGrid()$thresNew) / 1e6) {
+          updateTextInput(session, "bracketV5T", value = round(max(updateGrid()$thresNew) / 1e6, 0))
+        }
+      }
+    }
+  })
+
+  observe({
+    if (input$extraBrackets >= 6) {
+      if (!is.null(input$bracketV6T)) {
+        if (bracketVal6T() < 0) {
+          updateTextInput(session, "bracketV6T", value = 1)
+        }
+      }
+    }
+  })
+
+  observe({
+    if (input$extraBrackets >= 6) {
+      if (!is.null(input$bracketV6T)) {
+        if (bracketVal6T() > max(updateGrid()$thresNew) / 1e6) {
+          updateTextInput(session, "bracketV6T", value = round(max(updateGrid()$thresNew) / 1e6, 0))
+        }
+      }
+    }
+  })
+
+  observe({
+    if (input$extraBrackets >= 7) {
+      if (!is.null(input$bracketV7T)) {
+        if (bracketVal7T() < 0) {
+          updateTextInput(session, "bracketV7T", value = 1)
+        }
+      }
+    }
+  })
+
+  observe({
+    if (input$extraBrackets >= 7) {
+      if (!is.null(input$bracketV7T)) {
+        if (bracketVal7T() > max(updateGrid()$thresNew) / 1e6) {
+          updateTextInput(session, "bracketV7T", value = round(max(updateGrid()$thresNew) / 1e6, 0))
+        }
+      }
+    }
+  })
+
+  observe({
+    if (input$extraBrackets >= 8) {
+      if (!is.null(input$bracketV8T)) {
+        if (bracketVal8T() < 0) {
+          updateTextInput(session, "bracketV8T", value = 1)
+        }
+      }
+    }
+  })
+
+  observe({
+    if (input$extraBrackets >= 8) {
+      if (!is.null(input$bracketV8T)) {
+        if (bracketVal8T() > max(updateGrid()$thresNew) / 1e6) {
+          updateTextInput(session, "bracketV8T", value = round(max(updateGrid()$thresNew) / 1e6, 0))
+        }
+      }
+    }
+  })
+
+
+  ## helpers to call these values
   bracket1T <- reactive({
     req(input$bracket1T)
     as.numeric(input$bracket1T)
-    # print(input$bracket1) ## make sure doesn't have % included
   })
   bracket2T <- reactive({
     req(input$bracket2T)
@@ -508,23 +454,27 @@ observe({
     as.numeric(input$bracket4T)
   })
   bracket5T <- reactive({
-    if(input$extraBrackets>=5)
+    if (input$extraBrackets >= 5) {
       req(input$bracket5T)
+    }
     as.numeric(input$bracket5T)
   })
   bracket6T <- reactive({
-    if(input$extraBrackets>=6)
+    if (input$extraBrackets >= 6) {
       req(input$bracket6T)
+    }
     as.numeric(input$bracket6T)
   })
   bracket7T <- reactive({
-    if(input$extraBrackets>=7)
+    if (input$extraBrackets >= 7) {
       req(input$bracket7T)
+    }
     as.numeric(input$bracket7T)
   })
   bracket8T <- reactive({
-    if(input$extraBrackets>=8)
+    if (input$extraBrackets >= 8) {
       req(input$bracket8T)
+    }
     as.numeric(input$bracket8T)
   })
 
@@ -545,116 +495,118 @@ observe({
     as.numeric(input$bracketV4T)
   })
   bracketVal5T <- reactive({
-    if(input$extraBrackets>=5)
+    if (input$extraBrackets >= 5) {
       req(input$bracketV5T)
+    }
     as.numeric(input$bracketV5T)
   })
   bracketVal6T <- reactive({
-    if(input$extraBrackets>=6)
+    if (input$extraBrackets >= 6) {
       req(input$bracketV6T)
+    }
     as.numeric(input$bracketV6T)
   })
   bracketVal7T <- reactive({
-    if(input$extraBrackets>=7)
+    if (input$extraBrackets >= 7) {
       req(input$bracketV7T)
+    }
     as.numeric(input$bracketV7T)
   })
   bracketVal8T <- reactive({
-    if(input$extraBrackets>=8)
+    if (input$extraBrackets >= 8) {
       req(input$bracketV8T)
+    }
     as.numeric(input$bracketV8T)
   })
 
 
 
 
-
-  dataInputT <- #eventReactive(input$submit,ignoreNULL = FALSE,{
-    reactive({
-
+  ## get data ready to plot
+  dataInputT <- reactive({
     taxRate <- as.numeric(c(input$bracket1T, input$bracket2T, input$bracket3T, input$bracket4T))
 
-    if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
+    if (input$extraBrackets == 5 & !is.null(input$bracket5T)) {
       taxRate <- c(taxRate, as.numeric(input$bracket5T))
     }
-    if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
+    if (input$extraBrackets == 6 & !is.null(input$bracket6T)) {
       taxRate <- c(taxRate, as.numeric(input$bracket5T), as.numeric(input$bracket6T))
     }
-    if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
+    if (input$extraBrackets == 7 & !is.null(input$bracket7T)) {
       taxRate <- c(taxRate, as.numeric(input$bracket5T), as.numeric(input$bracket6T), as.numeric(input$bracket7T))
     }
-    if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
+    if (input$extraBrackets == 8 & !is.null(input$bracket8T)) {
       taxRate <- c(taxRate, as.numeric(input$bracket5T), as.numeric(input$bracket6T), as.numeric(input$bracket7T), as.numeric(input$bracket8T))
     }
 
     brackets <- as.numeric(c(bracketVal1T(), bracketVal2T(), bracketVal3T(), bracketVal4T()))
-    if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
+    if (input$extraBrackets == 5 & !is.null(input$bracket5T)) {
       brackets <- c(brackets, as.numeric(input$bracketV5T))
     }
-    if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
+    if (input$extraBrackets == 6 & !is.null(input$bracket6T)) {
       brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T))
     }
-    if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
-      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T),as.numeric(input$bracketV7T))
+    if (input$extraBrackets == 7 & !is.null(input$bracket7T)) {
+      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T), as.numeric(input$bracketV7T))
     }
-    if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
-      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T),as.numeric(input$bracketV7T), as.numeric(input$bracketV8T))
+    if (input$extraBrackets == 8 & !is.null(input$bracket8T)) {
+      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T), as.numeric(input$bracketV7T), as.numeric(input$bracketV8T))
     }
-    
-    reorderIdx=order(as.numeric(brackets))
-    brackets = brackets[reorderIdx]
-    taxRate=taxRate[reorderIdx]
-#browser()
+
+    ## reshuffle to make sure brackets are increasing
+    ## tax rates not forced to be monotonic
+    reorderIdx <- order(as.numeric(brackets))
+    brackets <- brackets[reorderIdx]
+    taxRate <- taxRate[reorderIdx]
+
     xval <- 10^seq(log10(1e6), log10(45e9), by = 0.001) ## get uniform on log scale
 
-idx0 <- xval <= as.numeric(brackets[1])*1e6
-    idx1 <- xval <= as.numeric(brackets[2]) * 1e6 & xval > as.numeric(brackets[1])*1e6
+    idx0 <- xval <= as.numeric(brackets[1]) * 1e6
+    idx1 <- xval <= as.numeric(brackets[2]) * 1e6 & xval > as.numeric(brackets[1]) * 1e6
     idx2 <- xval > as.numeric(brackets[2]) * 1e6 & xval <= as.numeric(brackets[3]) * 1e6
     idx3 <- xval > as.numeric(brackets[3]) * 1e6 & xval <= as.numeric(brackets[4]) * 1e6
 
-    if (input$extraBrackets==8 & !is.null(input$bracket8T)) { ## since nested, test this one first
+    if (input$extraBrackets == 8 & !is.null(input$bracket8T)) {
       idx4 <- xval > as.numeric(brackets[4]) * 1e6 & xval <= as.numeric(brackets[5]) * 1e6
       idx5 <- xval > as.numeric(brackets[5]) * 1e6 & xval <= as.numeric(brackets[6]) * 1e6
       idx6 <- xval > as.numeric(brackets[6]) * 1e6 & xval <= as.numeric(brackets[7]) * 1e6
       idx7 <- xval > as.numeric(brackets[7]) * 1e6 & xval <= as.numeric(brackets[8]) * 1e6
       idx8 <- xval > as.numeric(brackets[8])
-      idx <- cbind.data.frame(idx0,idx1, idx2, idx3, idx4, idx5, idx6, idx7, idx8)
-    } else if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
+      idx <- cbind.data.frame(idx0, idx1, idx2, idx3, idx4, idx5, idx6, idx7, idx8)
+    } else if (input$extraBrackets == 7 & !is.null(input$bracket7T)) {
       idx4 <- xval > as.numeric(brackets[4]) * 1e6 & xval <= as.numeric(brackets[5]) * 1e6
       idx5 <- xval > as.numeric(brackets[5]) * 1e6 & xval <= as.numeric(brackets[6]) * 1e6
       idx6 <- xval > as.numeric(brackets[6]) * 1e6 & xval <= as.numeric(brackets[7]) * 1e6
       idx7 <- xval > as.numeric(brackets[7]) * 1e6
-      idx <- cbind.data.frame(idx0,idx1, idx2, idx3, idx4, idx5, idx6, idx7)
-    } else if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
+      idx <- cbind.data.frame(idx0, idx1, idx2, idx3, idx4, idx5, idx6, idx7)
+    } else if (input$extraBrackets == 6 & !is.null(input$bracket6T)) {
       idx4 <- xval > as.numeric(brackets[4]) * 1e6 & xval <= as.numeric(brackets[5]) * 1e6
       idx5 <- xval > as.numeric(brackets[5]) * 1e6 & xval <= as.numeric(brackets[6]) * 1e6
       idx6 <- xval > as.numeric(brackets[6]) * 1e6
-      idx <- cbind.data.frame(idx0,idx1, idx2, idx3, idx4, idx5, idx6)
-    } else if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
+      idx <- cbind.data.frame(idx0, idx1, idx2, idx3, idx4, idx5, idx6)
+    } else if (input$extraBrackets == 5 & !is.null(input$bracket5T)) {
       idx4 <- xval > as.numeric(brackets[4]) * 1e6 & xval <= as.numeric(brackets[5]) * 1e6
       idx5 <- xval > as.numeric(brackets[5]) * 1e6
-      idx <- cbind.data.frame(idx0,idx1, idx2, idx3, idx4, idx5)
+      idx <- cbind.data.frame(idx0, idx1, idx2, idx3, idx4, idx5)
     } else {
       idx4 <- xval > as.numeric(brackets[4]) * 1e6
-      idx <- cbind.data.frame(idx0,idx1, idx2, idx3, idx4)
+      idx <- cbind.data.frame(idx0, idx1, idx2, idx3, idx4)
     }
 
 
 
-    # Indicator across income on tax bracke position
+    # Indicator across income on tax bracket position
     getGroup <- unlist(apply(idx, 1, function(x) {
       which(x)[1]
     }))
-    # getGroup <- as.numeric(cut(xval, c(brackets_po, 1e12), include.lowest = TRUE))
 
 
     toPlot <- cbind.data.frame(xval, getGroup)
 
-    toMatch <- cbind.data.frame(group = 1:(length(taxRate)+1), tax = c(0,taxRate))
+    ## add an extra ghost bracket to the end that isn't taxed
+    toMatch <- cbind.data.frame(group = 1:(length(taxRate) + 1), tax = c(0, taxRate))
 
     toPlot2 <- merge(toPlot, toMatch, by.x = "getGroup", by.y = "group")
-
-    
 
 
     # unaffected by new grouping
@@ -662,16 +614,15 @@ idx0 <- xval <= as.numeric(brackets[1])*1e6
 
     toPlot2$marginalRate <- (toPlot2$marginalInt / toPlot2$xval) * 100
 
-#browser()
 
-head(toPlot2)
+    head(toPlot2)
     toPlot2$id <- 1:nrow(toPlot2)
 
     toPlot2
   })
 
 
-  # Computes total tax revenue
+  # Computes total tax revenue, avg happens later
   getAverageTax <- function(wealth, taxLevels, brackets) {
     ## pass in brackets to make sure they update
     ## expecting taxLevels in percentage
@@ -736,7 +687,9 @@ head(toPlot2)
     return(toReturn)
   }
 
+  ## total tax helper
   totalTax <- reactive({
+    ## wait for brackets to be ready
     req(input$bracket1T)
     req(input$bracket2T)
     req(input$bracket3T)
@@ -745,54 +698,58 @@ head(toPlot2)
     req(input$bracketV2T)
     req(input$bracketV3T)
     req(input$bracketV4T)
-      taxRate <- as.numeric(c(input$bracket1T, input$bracket2T, input$bracket3T, input$bracket4T))
-      if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
-        taxRate <- c(taxRate, input$bracket5T)
-      }
-      if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
-        taxRate <- c(taxRate,  input$bracket5T, input$bracket6T)
-      }
-      if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
-        taxRate <- c(taxRate, input$bracket5T, input$bracket6T, input$bracket7T)
-      }
-      if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
-        taxRate <- c(taxRate, input$bracket5T, input$bracket6T, input$bracket7T, input$bracket8T)
-      }
-      taxRateP <- as.numeric(taxRate) / 100 ## get to percentage
-      bracketStarts <- 1e6 * as.numeric(c(input$bracketV1T, input$bracketV2T, input$bracketV3T, input$bracketV4T))
-      if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
-        bracketStarts <- c(bracketStarts, 1e6 * as.numeric(input$bracketV5T))
-      }
-      if (input$extraBrackets==6 &  !is.null(input$bracket6T)) {
-        bracketStarts <- c(bracketStarts, 1e6 * as.numeric(input$bracketV5T), 1e6 * as.numeric(input$bracketV6T))
-      }
-      if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
-        bracketStarts <- c(bracketStarts, 1e6 * as.numeric(input$bracketV5T), 1e6 * as.numeric(input$bracketV6T),1e6 * as.numeric(input$bracketV7T))
-      }
-      if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
-        bracketStarts <- c(bracketStarts, 1e6 * as.numeric(input$bracketV5T), 1e6 * as.numeric(input$bracketV6T),1e6 * as.numeric(input$bracketV7T),1e6 * as.numeric(input$bracketV8T))
-      }
-      
-      reorderIdx=order(as.numeric(bracketStarts))
-      bracketStarts = bracketStarts[reorderIdx]
-      taxRate=taxRate[reorderIdx]
-    
-    taxPerBracket <- getTaxBasePerBracket(updateGrid(), as.numeric(taxRate),as.numeric(bracketStarts))
-   
-taxPerBracket/1e9 ## in billions
+    taxRate <- as.numeric(c(input$bracket1T, input$bracket2T, input$bracket3T, input$bracket4T))
+    if (input$extraBrackets == 5 & !is.null(input$bracket5T)) {
+      taxRate <- c(taxRate, input$bracket5T)
+    }
+    if (input$extraBrackets == 6 & !is.null(input$bracket6T)) {
+      taxRate <- c(taxRate, input$bracket5T, input$bracket6T)
+    }
+    if (input$extraBrackets == 7 & !is.null(input$bracket7T)) {
+      taxRate <- c(taxRate, input$bracket5T, input$bracket6T, input$bracket7T)
+    }
+    if (input$extraBrackets == 8 & !is.null(input$bracket8T)) {
+      taxRate <- c(taxRate, input$bracket5T, input$bracket6T, input$bracket7T, input$bracket8T)
+    }
+    taxRateP <- as.numeric(taxRate) / 100 ## get to percentage
+    bracketStarts <- 1e6 * as.numeric(c(input$bracketV1T, input$bracketV2T, input$bracketV3T, input$bracketV4T))
+    if (input$extraBrackets == 5 & !is.null(input$bracket5T)) {
+      bracketStarts <- c(bracketStarts, 1e6 * as.numeric(input$bracketV5T))
+    }
+    if (input$extraBrackets == 6 & !is.null(input$bracket6T)) {
+      bracketStarts <- c(bracketStarts, 1e6 * as.numeric(input$bracketV5T), 1e6 * as.numeric(input$bracketV6T))
+    }
+    if (input$extraBrackets == 7 & !is.null(input$bracket7T)) {
+      bracketStarts <- c(bracketStarts, 1e6 * as.numeric(input$bracketV5T), 1e6 * as.numeric(input$bracketV6T), 1e6 * as.numeric(input$bracketV7T))
+    }
+    if (input$extraBrackets == 8 & !is.null(input$bracket8T)) {
+      bracketStarts <- c(bracketStarts, 1e6 * as.numeric(input$bracketV5T), 1e6 * as.numeric(input$bracketV6T), 1e6 * as.numeric(input$bracketV7T), 1e6 * as.numeric(input$bracketV8T))
+    }
+
+    reorderIdx <- order(as.numeric(bracketStarts))
+    bracketStarts <- bracketStarts[reorderIdx]
+    taxRate <- taxRate[reorderIdx]
+
+    taxPerBracket <- getTaxBasePerBracket(updateGrid(), as.numeric(taxRate), as.numeric(bracketStarts))
+
+    taxPerBracket / 1e9 ## in billions
   })
 
+  ## total tax output
   output$totalTax <- renderText({
     round(totalTax())
   })
 
+  ## total tax output over 10 years
   output$totalTax_10 <- renderText({
     totalTax10 <- totalTax() * 13
 
     round(totalTax10 / 1e3, 2)
   })
 
+  ## total number of households taxed helper
   householdsTaxed <- reactive({
+    ## wait for things to be ready
     req(input$bracket1T)
     req(input$bracket2T)
     req(input$bracket3T)
@@ -801,187 +758,174 @@ taxPerBracket/1e9 ## in billions
     req(input$bracketV2T)
     req(input$bracketV3T)
     req(input$bracketV4T)
-  
-      taxRate <- as.numeric(c(input$bracket1T, input$bracket2T, input$bracket3T, input$bracket4T))
-      if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
-        taxRate <- c(taxRate, input$bracket5T)
-      }
-      if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
-        taxRate <- c(taxRate, input$bracket5T, input$bracket6T)
-      }
-      if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
-        taxRate <- c(taxRate, input$bracket5T, input$bracket6T, input$bracket7T)
-      }
-      if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
-        taxRate <- c(taxRate, input$bracket5T, input$bracket6T, input$bracket7T,input$bracket8T)
-      }
-      taxRateP <- as.numeric(taxRate) / 100 ## get to percentage
 
-      bracketStarts <- 1e6 * as.numeric(c(input$bracketV1T, input$bracketV2T, input$bracketV3T, input$bracketV4T))
-      if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
-        bracketStarts <- c(bracketStarts, 1e6 * as.numeric(input$bracketV5T))
-      }
-      if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
-        bracketStarts <- c(bracketStarts, 1e6 * as.numeric(input$bracketV5T),1e6 * as.numeric(input$bracketV6T))
-      }
-      if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
-        bracketStarts <- c(bracketStarts, 1e6 * as.numeric(input$bracketV5T),1e6 * as.numeric(input$bracketV6T), 1e6 * as.numeric(input$bracketV7T))
-      }
-      if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
-        bracketStarts <- c(bracketStarts, 1e6 * as.numeric(input$bracketV5T),1e6 * as.numeric(input$bracketV6T), 1e6 * as.numeric(input$bracketV7T), 1e6 * as.numeric(input$bracketV8T))
-      }
-      
-      reorderIdx=order(as.numeric(bracketStarts))
-      bracketStarts = bracketStarts[reorderIdx]
-      taxRate=taxRate[reorderIdx]
-    
+    taxRate <- as.numeric(c(input$bracket1T, input$bracket2T, input$bracket3T, input$bracket4T))
+    if (input$extraBrackets == 5 & !is.null(input$bracket5T)) {
+      taxRate <- c(taxRate, input$bracket5T)
+    }
+    if (input$extraBrackets == 6 & !is.null(input$bracket6T)) {
+      taxRate <- c(taxRate, input$bracket5T, input$bracket6T)
+    }
+    if (input$extraBrackets == 7 & !is.null(input$bracket7T)) {
+      taxRate <- c(taxRate, input$bracket5T, input$bracket6T, input$bracket7T)
+    }
+    if (input$extraBrackets == 8 & !is.null(input$bracket8T)) {
+      taxRate <- c(taxRate, input$bracket5T, input$bracket6T, input$bracket7T, input$bracket8T)
+    }
+    taxRateP <- as.numeric(taxRate) / 100 ## get to percentage
+
+    bracketStarts <- 1e6 * as.numeric(c(input$bracketV1T, input$bracketV2T, input$bracketV3T, input$bracketV4T))
+    if (input$extraBrackets == 5 & !is.null(input$bracket5T)) {
+      bracketStarts <- c(bracketStarts, 1e6 * as.numeric(input$bracketV5T))
+    }
+    if (input$extraBrackets == 6 & !is.null(input$bracket6T)) {
+      bracketStarts <- c(bracketStarts, 1e6 * as.numeric(input$bracketV5T), 1e6 * as.numeric(input$bracketV6T))
+    }
+    if (input$extraBrackets == 7 & !is.null(input$bracket7T)) {
+      bracketStarts <- c(bracketStarts, 1e6 * as.numeric(input$bracketV5T), 1e6 * as.numeric(input$bracketV6T), 1e6 * as.numeric(input$bracketV7T))
+    }
+    if (input$extraBrackets == 8 & !is.null(input$bracket8T)) {
+      bracketStarts <- c(bracketStarts, 1e6 * as.numeric(input$bracketV5T), 1e6 * as.numeric(input$bracketV6T), 1e6 * as.numeric(input$bracketV7T), 1e6 * as.numeric(input$bracketV8T))
+    }
+
+    reorderIdx <- order(as.numeric(bracketStarts))
+    bracketStarts <- bracketStarts[reorderIdx]
+    taxRate <- taxRate[reorderIdx]
+
     peoplePerBracket <- getPeoplePerBracket(updateGrid(), bracketStarts)
     numberTaxpayers <- peoplePerBracket$totalPeople
-  if(length(numberTaxpayers)!=length(taxRateP)){
-    return(NA)
-  }else{
-    householdsTaxed <- numberTaxpayers * (taxRateP > 0)
-    
-    return(householdsTaxed)
-  }
+    if (length(numberTaxpayers) != length(taxRateP)) {
+      return(NA)
+    } else {
+      householdsTaxed <- numberTaxpayers * (taxRateP > 0)
+
+      return(householdsTaxed)
+    }
   })
 
+  ## output total taxpayers
   output$totalTaxpayers <- renderText({
     totalTaxpayers <- sum(householdsTaxed())
 
     round(totalTaxpayers)
   })
 
-  # output$percentHouseAffected <- renderText({
-  #   #browser()
-  #   householdsAffected <- sum(householdsTaxed()) / 129.4e6 ## make the denominator updateable later
-  #
-  #   round(householdsAffected * 100, 1) ## get to percentage
-  # })
-
-  ## fix
+  ## use percentile affected
   output$percentTaxUnits <- renderText({
     taxRate <- as.numeric(c(input$bracket1T, input$bracket2T, input$bracket3T, input$bracket4T))
-    
-    if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
+
+    if (input$extraBrackets == 5 & !is.null(input$bracket5T)) {
       taxRate <- c(taxRate, as.numeric(input$bracket5T))
     }
-    if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
+    if (input$extraBrackets == 6 & !is.null(input$bracket6T)) {
       taxRate <- c(taxRate, as.numeric(input$bracket5T), as.numeric(input$bracket6T))
     }
-    if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
+    if (input$extraBrackets == 7 & !is.null(input$bracket7T)) {
       taxRate <- c(taxRate, as.numeric(input$bracket5T), as.numeric(input$bracket6T), as.numeric(input$bracket7T))
     }
-    if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
+    if (input$extraBrackets == 8 & !is.null(input$bracket8T)) {
       taxRate <- c(taxRate, as.numeric(input$bracket5T), as.numeric(input$bracket6T), as.numeric(input$bracket7T), as.numeric(input$bracket8T))
     }
-    
+
     brackets <- as.numeric(c(bracketVal1T(), bracketVal2T(), bracketVal3T(), bracketVal4T()))
-    if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
+    if (input$extraBrackets == 5 & !is.null(input$bracket5T)) {
       brackets <- c(brackets, as.numeric(input$bracketV5T))
     }
-    if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
+    if (input$extraBrackets == 6 & !is.null(input$bracket6T)) {
       brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T))
     }
-    if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
-      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T),as.numeric(input$bracketV7T))
+    if (input$extraBrackets == 7 & !is.null(input$bracket7T)) {
+      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T), as.numeric(input$bracketV7T))
     }
-    if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
-      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T),as.numeric(input$bracketV7T), as.numeric(input$bracketV8T))
+    if (input$extraBrackets == 8 & !is.null(input$bracket8T)) {
+      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T), as.numeric(input$bracketV7T), as.numeric(input$bracketV8T))
     }
-    
-    reorderIdx=order(as.numeric(brackets))
-    brackets = brackets[reorderIdx]
-    taxRate=taxRate[reorderIdx]
-    
-    
-    
-    getPercentile(updateGrid(),brackets[which(taxRate>0)[1]])
-    
+
+    reorderIdx <- order(as.numeric(brackets))
+    brackets <- brackets[reorderIdx]
+    taxRate <- taxRate[reorderIdx]
+
+
+
+    getPercentile(updateGrid(), brackets[which(taxRate > 0)[1]])
   })
 
-#https://github.com/rstudio/shiny/issues/1125
-  vis2 <- eventReactive(input$submit,ignoreNULL = FALSE,{
-    #reactive({
-
+  vis2 <- eventReactive(input$submit, ignoreNULL = FALSE, {
     req(input$bracket1T)
     req(input$bracket2T)
     req(input$bracket3T)
     req(input$bracket4T)
-    
-      taxRate <- as.numeric(c(input$bracket1T, input$bracket2T, input$bracket3T, input$bracket4T))
-      if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
-        taxRate <- c(taxRate, as.numeric(input$bracket5T))
-      }
-      if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
-        taxRate <- c(taxRate, as.numeric(input$bracket5T), as.numeric(input$bracket6T))
-      }
-      if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
-        taxRate <- c(taxRate, as.numeric(input$bracket5T), as.numeric(input$bracket6T),as.numeric(input$bracket7T))
-      }
-      if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
-        taxRate <- c(taxRate, as.numeric(input$bracket5T), as.numeric(input$bracket6T),as.numeric(input$bracket7T),as.numeric(input$bracket8T))
-      }
-      
-      brackets <- as.numeric(c(bracketVal1T(), bracketVal2T(), bracketVal3T(), bracketVal4T()))
-      if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
-        brackets <- c(brackets, as.numeric(input$bracketV5T))
-      }
-      if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
-        brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T))
-      }
-      if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
-        brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T),as.numeric(input$bracketV7T))
-      }
-      if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
-        brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T),as.numeric(input$bracketV7T), as.numeric(input$bracketV8T))
-      }
-      
 
-      #browser()
-      reorderIdx=order(as.numeric(brackets))
-      brackets = brackets[reorderIdx]
-      taxRate=taxRate[reorderIdx]
-      
-      # These are mini data set that ggvis needs to create vertical lines
-      extra0 <- cbind.data.frame(x = rep(as.numeric(brackets[1]) * 1e6, 2), y = c(0, taxRate[1]))
-      extra1 <- cbind.data.frame(x = rep(as.numeric(brackets[2]) * 1e6, 2), y = c(0, taxRate[1]))
-      extra1b <- cbind.data.frame(x = rep(as.numeric(brackets[2]) * 1e6, 2), y = c(0, taxRate[2]))
-      extra2 <- cbind.data.frame(x = rep(as.numeric(brackets[3]) * 1e6, 2), y = c(0, taxRate[2]))
-      extra2b <- cbind.data.frame(x = rep(as.numeric(brackets[3]) * 1e6, 2), y = c(0, taxRate[3]))
-      extra3 <- cbind.data.frame(x = rep(as.numeric(brackets[4]) * 1e6, 2), y = c(0, taxRate[3]))
-      extra3b <- cbind.data.frame(x = rep(as.numeric(brackets[4]) * 1e6, 2), y = c(0, taxRate[4]))
-      if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
-        extra4 <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[4]))
-        extra4b <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[5]))
-      }
-      if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
-        extra4 <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[4]))
-        extra4b <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[5]))
-        extra5 <- cbind.data.frame(x = rep(as.numeric(brackets[6]) * 1e6, 2), y = c(0, taxRate[5]))
-        extra5b <- cbind.data.frame(x = rep(as.numeric(brackets[6]) * 1e6, 2), y = c(0, taxRate[6]))
-      }
-      if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
-        extra4 <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[4]))
-        extra4b <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[5]))
-        extra5 <- cbind.data.frame(x = rep(as.numeric(brackets[6]) * 1e6, 2), y = c(0, taxRate[5]))
-        extra5b <- cbind.data.frame(x = rep(as.numeric(brackets[6]) * 1e6, 2), y = c(0, taxRate[6]))
-        extra6 <- cbind.data.frame(x = rep(as.numeric(brackets[7]) * 1e6, 2), y = c(0, taxRate[6]))
-        extra6b <- cbind.data.frame(x = rep(as.numeric(brackets[7]) * 1e6, 2), y = c(0, taxRate[7]))
-      }
-      if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
-        extra4 <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[4]))
-        extra4b <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[5]))
-        extra5 <- cbind.data.frame(x = rep(as.numeric(brackets[6]) * 1e6, 2), y = c(0, taxRate[5]))
-        extra5b <- cbind.data.frame(x = rep(as.numeric(brackets[6]) * 1e6, 2), y = c(0, taxRate[6]))
-        extra6 <- cbind.data.frame(x = rep(as.numeric(brackets[7]) * 1e6, 2), y = c(0, taxRate[6]))
-        extra6b <- cbind.data.frame(x = rep(as.numeric(brackets[7]) * 1e6, 2), y = c(0, taxRate[7]))
-        extra7 <- cbind.data.frame(x = rep(as.numeric(brackets[8]) * 1e6, 2), y = c(0, taxRate[7]))
-        extra7b <- cbind.data.frame(x = rep(as.numeric(brackets[8]) * 1e6, 2), y = c(0, taxRate[8]))
-      }
-    
+    taxRate <- as.numeric(c(input$bracket1T, input$bracket2T, input$bracket3T, input$bracket4T))
+    if (input$extraBrackets == 5 & !is.null(input$bracket5T)) {
+      taxRate <- c(taxRate, as.numeric(input$bracket5T))
+    }
+    if (input$extraBrackets == 6 & !is.null(input$bracket6T)) {
+      taxRate <- c(taxRate, as.numeric(input$bracket5T), as.numeric(input$bracket6T))
+    }
+    if (input$extraBrackets == 7 & !is.null(input$bracket7T)) {
+      taxRate <- c(taxRate, as.numeric(input$bracket5T), as.numeric(input$bracket6T), as.numeric(input$bracket7T))
+    }
+    if (input$extraBrackets == 8 & !is.null(input$bracket8T)) {
+      taxRate <- c(taxRate, as.numeric(input$bracket5T), as.numeric(input$bracket6T), as.numeric(input$bracket7T), as.numeric(input$bracket8T))
+    }
 
-    ## rename to showAvg
+    brackets <- as.numeric(c(bracketVal1T(), bracketVal2T(), bracketVal3T(), bracketVal4T()))
+    if (input$extraBrackets == 5 & !is.null(input$bracket5T)) {
+      brackets <- c(brackets, as.numeric(input$bracketV5T))
+    }
+    if (input$extraBrackets == 6 & !is.null(input$bracket6T)) {
+      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T))
+    }
+    if (input$extraBrackets == 7 & !is.null(input$bracket7T)) {
+      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T), as.numeric(input$bracketV7T))
+    }
+    if (input$extraBrackets == 8 & !is.null(input$bracket8T)) {
+      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T), as.numeric(input$bracketV7T), as.numeric(input$bracketV8T))
+    }
+
+
+    reorderIdx <- order(as.numeric(brackets))
+    brackets <- brackets[reorderIdx]
+    taxRate <- taxRate[reorderIdx]
+
+    # These are mini data set that ggvis needs to create vertical lines
+    extra0 <- cbind.data.frame(x = rep(as.numeric(brackets[1]) * 1e6, 2), y = c(0, taxRate[1]))
+    extra1 <- cbind.data.frame(x = rep(as.numeric(brackets[2]) * 1e6, 2), y = c(0, taxRate[1]))
+    extra1b <- cbind.data.frame(x = rep(as.numeric(brackets[2]) * 1e6, 2), y = c(0, taxRate[2]))
+    extra2 <- cbind.data.frame(x = rep(as.numeric(brackets[3]) * 1e6, 2), y = c(0, taxRate[2]))
+    extra2b <- cbind.data.frame(x = rep(as.numeric(brackets[3]) * 1e6, 2), y = c(0, taxRate[3]))
+    extra3 <- cbind.data.frame(x = rep(as.numeric(brackets[4]) * 1e6, 2), y = c(0, taxRate[3]))
+    extra3b <- cbind.data.frame(x = rep(as.numeric(brackets[4]) * 1e6, 2), y = c(0, taxRate[4]))
+    if (input$extraBrackets == 5 & !is.null(input$bracket5T)) {
+      extra4 <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[4]))
+      extra4b <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[5]))
+    }
+    if (input$extraBrackets == 6 & !is.null(input$bracket6T)) {
+      extra4 <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[4]))
+      extra4b <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[5]))
+      extra5 <- cbind.data.frame(x = rep(as.numeric(brackets[6]) * 1e6, 2), y = c(0, taxRate[5]))
+      extra5b <- cbind.data.frame(x = rep(as.numeric(brackets[6]) * 1e6, 2), y = c(0, taxRate[6]))
+    }
+    if (input$extraBrackets == 7 & !is.null(input$bracket7T)) {
+      extra4 <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[4]))
+      extra4b <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[5]))
+      extra5 <- cbind.data.frame(x = rep(as.numeric(brackets[6]) * 1e6, 2), y = c(0, taxRate[5]))
+      extra5b <- cbind.data.frame(x = rep(as.numeric(brackets[6]) * 1e6, 2), y = c(0, taxRate[6]))
+      extra6 <- cbind.data.frame(x = rep(as.numeric(brackets[7]) * 1e6, 2), y = c(0, taxRate[6]))
+      extra6b <- cbind.data.frame(x = rep(as.numeric(brackets[7]) * 1e6, 2), y = c(0, taxRate[7]))
+    }
+    if (input$extraBrackets == 8 & !is.null(input$bracket8T)) {
+      extra4 <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[4]))
+      extra4b <- cbind.data.frame(x = rep(as.numeric(brackets[5]) * 1e6, 2), y = c(0, taxRate[5]))
+      extra5 <- cbind.data.frame(x = rep(as.numeric(brackets[6]) * 1e6, 2), y = c(0, taxRate[5]))
+      extra5b <- cbind.data.frame(x = rep(as.numeric(brackets[6]) * 1e6, 2), y = c(0, taxRate[6]))
+      extra6 <- cbind.data.frame(x = rep(as.numeric(brackets[7]) * 1e6, 2), y = c(0, taxRate[6]))
+      extra6b <- cbind.data.frame(x = rep(as.numeric(brackets[7]) * 1e6, 2), y = c(0, taxRate[7]))
+      extra7 <- cbind.data.frame(x = rep(as.numeric(brackets[8]) * 1e6, 2), y = c(0, taxRate[7]))
+      extra7b <- cbind.data.frame(x = rep(as.numeric(brackets[8]) * 1e6, 2), y = c(0, taxRate[8]))
+    }
+
 
     showAvg <- function(x) {
       # https://stackoverflow.com/questions/28396900/r-ggvis-html-function-failing-to-add-tooltip/28399656#28399656
@@ -989,22 +933,21 @@ taxPerBracket/1e9 ## in billions
       if (sum(grepl("id", names(x))) == 0) return(NULL)
       if (is.null(x)) return(NULL)
 
-      
-        data <- dataInputT()
+
+      data <- dataInputT()
 
 
 
       row <- data[data$id == x$id, ]
 
-      paste0("Average Tax Rate: ", round(row$marginalRate, 2), "%", " <br> Wealth ($m): ", round(row$xval / 1e6, 0),"<br> Top ",getPercentile(updateGrid(),row$xval / 1e6),"%", "<br> Taxes Paid ($m): ", round(row$marginalInt / 1e6, 2), sep = "") ## dividing by 1e6 may need to change if we do this for xval overall
+      paste0("Average Tax Rate: ", round(row$marginalRate, 2), "%", " <br> Wealth ($m): ", round(row$xval / 1e6, 0), "<br> Top ", getPercentile(updateGrid(), row$xval / 1e6), "%", "<br> Taxes Paid ($m): ", round(row$marginalInt / 1e6, 2), sep = "") ## dividing by 1e6 may need to change if we do this for xval overall
     }
 
-    # plot <- dataInput()[, -ncol(dataInput())] %>%
 
-    
-      data <- dataInputT()
 
-      
+    data <- dataInputT()
+
+
 
     rmIdx <- ncol(data)
     plot <- data[, -rmIdx] %>%
@@ -1020,12 +963,14 @@ taxPerBracket/1e9 ## in billions
       layer_paths(data = extra1b, ~ x / 1e6, ~y) %>%
       layer_paths(data = extra2b, ~ x / 1e6, ~y) %>%
       layer_paths(data = extra3b, ~ x / 1e6, ~y) %>%
-      add_axis("x", title_offset = 80, title = "Wealth ($m)", grid = F, format = ",",
-               values = brackets,properties = axis_props(labels = list(angle = 45, align = "left", baseline = "middle"))) %>%
+      add_axis("x",
+        title_offset = 80, title = "Wealth ($m)", grid = F, format = ",",
+        values = brackets, properties = axis_props(labels = list(angle = 45, align = "left", baseline = "middle"))
+      ) %>%
       add_axis("y", title = "Tax rate (%)") %>%
       scale_numeric("x", trans = "log", expand = 0) %>%
       set_options(width = 1000, height = 500)
-    if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
+    if (input$extraBrackets == 8 & !is.null(input$bracket8T)) {
       plot %>%
         layer_paths(data = extra4, ~ x / 1e6, ~y) %>%
         layer_paths(data = extra4b, ~ x / 1e6, ~y) %>%
@@ -1035,7 +980,7 @@ taxPerBracket/1e9 ## in billions
         layer_paths(data = extra6b, ~ x / 1e6, ~y) %>%
         layer_paths(data = extra7, ~ x / 1e6, ~y) %>%
         layer_paths(data = extra7b, ~ x / 1e6, ~y)
-    } else if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
+    } else if (input$extraBrackets == 7 & !is.null(input$bracket7T)) {
       plot %>%
         layer_paths(data = extra4, ~ x / 1e6, ~y) %>%
         layer_paths(data = extra4b, ~ x / 1e6, ~y) %>%
@@ -1043,13 +988,13 @@ taxPerBracket/1e9 ## in billions
         layer_paths(data = extra5b, ~ x / 1e6, ~y) %>%
         layer_paths(data = extra6, ~ x / 1e6, ~y) %>%
         layer_paths(data = extra6b, ~ x / 1e6, ~y)
-    } else if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
+    } else if (input$extraBrackets == 6 & !is.null(input$bracket6T)) {
       plot %>%
         layer_paths(data = extra4, ~ x / 1e6, ~y) %>%
         layer_paths(data = extra4b, ~ x / 1e6, ~y) %>%
         layer_paths(data = extra5, ~ x / 1e6, ~y) %>%
         layer_paths(data = extra5b, ~ x / 1e6, ~y)
-    } else if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
+    } else if (input$extraBrackets == 5 & !is.null(input$bracket5T)) {
       plot %>%
         layer_paths(data = extra4, ~ x / 1e6, ~y) %>%
         layer_paths(data = extra4b, ~ x / 1e6, ~y)

--- a/interactive_visualization/server.R
+++ b/interactive_visualization/server.R
@@ -859,11 +859,45 @@ taxPerBracket/1e9 ## in billions
   #   round(householdsAffected * 100, 1) ## get to percentage
   # })
 
+  ## fix
   output$percentTaxUnits <- renderText({
-    taxUnits <- sum(householdsTaxed()) / sum(updateGrid()$nb)
-    ## double check
-
-    round(taxUnits * 100, 2) ## get to percentage
+    taxRate <- as.numeric(c(input$bracket1T, input$bracket2T, input$bracket3T, input$bracket4T))
+    
+    if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
+      taxRate <- c(taxRate, as.numeric(input$bracket5T))
+    }
+    if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
+      taxRate <- c(taxRate, as.numeric(input$bracket5T), as.numeric(input$bracket6T))
+    }
+    if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
+      taxRate <- c(taxRate, as.numeric(input$bracket5T), as.numeric(input$bracket6T), as.numeric(input$bracket7T))
+    }
+    if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
+      taxRate <- c(taxRate, as.numeric(input$bracket5T), as.numeric(input$bracket6T), as.numeric(input$bracket7T), as.numeric(input$bracket8T))
+    }
+    
+    brackets <- as.numeric(c(bracketVal1T(), bracketVal2T(), bracketVal3T(), bracketVal4T()))
+    if (input$extraBrackets==5 & !is.null(input$bracket5T)) {
+      brackets <- c(brackets, as.numeric(input$bracketV5T))
+    }
+    if (input$extraBrackets==6 & !is.null(input$bracket6T)) {
+      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T))
+    }
+    if (input$extraBrackets==7 & !is.null(input$bracket7T)) {
+      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T),as.numeric(input$bracketV7T))
+    }
+    if (input$extraBrackets==8 & !is.null(input$bracket8T)) {
+      brackets <- c(brackets, as.numeric(input$bracketV5T), as.numeric(input$bracketV6T),as.numeric(input$bracketV7T), as.numeric(input$bracketV8T))
+    }
+    
+    reorderIdx=order(as.numeric(brackets))
+    brackets = brackets[reorderIdx]
+    taxRate=taxRate[reorderIdx]
+    
+    
+    
+    getPercentile(updateGrid(),brackets[which(taxRate>0)[1]])
+    
   })
 
 #https://github.com/rstudio/shiny/issues/1125

--- a/interactive_visualization/server.R
+++ b/interactive_visualization/server.R
@@ -2,6 +2,7 @@
 server <- function(input, output, session) {
   
   observeEvent(input$reset,{
+    click("submit")
     reset("extraBrackets")
     reset("evasion")
     reset("bracket1T")
@@ -23,7 +24,7 @@ server <- function(input, output, session) {
     # reset("bracketV7T")
     # reset("bracketV8T")
     
-  
+
   })
   
   ##https://stackoverflow.com/questions/39627760/conditional-panel-in-shiny-doesnt-update-variables

--- a/interactive_visualization/ui.R
+++ b/interactive_visualization/ui.R
@@ -12,7 +12,7 @@ ui <-
     useShinyjs(),
     titlePanel("Wealth Tax Explorer"),
     #radioButtons("interface", "What interface do you prefer?", c("Sliders" = 1, "Manual Input" = 2), selected = 1),
-    numericInput("extraBrackets", "Number of Brackets", 5, min = 4, max = 8),
+    numericInput("extraBrackets", "Number of Brackets", 4, min = 4, max = 8),
     textInput("evasion", label = "Tax Evasion (%)", value = "16"),
     #hidden( numericInput( inputId = 'refresh_helper', value = 0,label="" ) ),
     

--- a/interactive_visualization/ui.R
+++ b/interactive_visualization/ui.R
@@ -99,7 +99,7 @@ tags$a(href="https://github.com/fhoces/opa-wealthtax/blob/master/credits.md", "S
         textOutput("totalTax_10"),
         h4("Total Taxpayers"), ##  (CHECK UNITS)
         textOutput("totalTaxpayers"),
-        h4("Percentage of Tax Units Affected"), ## (CHECK UNITS)
+        h4("Percentage of Families Affected"), ## (CHECK UNITS)
         textOutput("percentTaxUnits")
       )
     )

--- a/interactive_visualization/ui.R
+++ b/interactive_visualization/ui.R
@@ -16,8 +16,8 @@ ui <-
     textInput("evasion", label = "Tax Evasion (%)", value = "16"),
     #hidden( numericInput( inputId = 'refresh_helper', value = 0,label="" ) ),
     
-    actionButton("reset", "Reset"),
-    actionButton("submit", "Recalculate"),
+    actionButton("reset", "Reset Values"),
+    actionButton("submit", "Update Plot"),
     fluidRow(
       column(
         2,

--- a/interactive_visualization/ui.R
+++ b/interactive_visualization/ui.R
@@ -86,16 +86,14 @@ ui <-
 
       column(
         8,
-        ggvisOutput("plot2"), ## comment out for now until ui is working
-        # ggvisOutput("plotB"),
-
+        ggvisOutput("plot2"), 
         h3("Total Taxes ($bn)"),
         textOutput("totalTax"),
         h4("Total Taxes over 10 years ($t)"),
         textOutput("totalTax_10"),
-        h4("Total Taxpayers"), ##  (CHECK UNITS)
+        h4("Total Taxpayers"), 
         textOutput("totalTaxpayers"),
-        h4("Percentage of Families Affected"), ## (CHECK UNITS)
+        h4("Percentage of Families Affected"), 
         textOutput("percentTaxUnits")
       )
     )

--- a/interactive_visualization/ui.R
+++ b/interactive_visualization/ui.R
@@ -2,7 +2,7 @@ library(ggvis)
 library(tidyr)
 library(dplyr)
 library(ggplot2)
-library(shinyjs) ## binder
+library(shinyjs)
 ## template from here
 ## https://github.com/rstudio/shiny-examples/tree/master/051-movie-explorer
 
@@ -11,32 +11,31 @@ ui <-
   fluidPage(
     useShinyjs(),
     titlePanel("Wealth Tax Explorer"),
-    #radioButtons("interface", "What interface do you prefer?", c("Sliders" = 1, "Manual Input" = 2), selected = 1),
+
     numericInput("extraBrackets", "Number of Brackets", 4, min = 4, max = 8),
     textInput("evasion", label = "Tax Evasion (%)", value = "16"),
-    #hidden( numericInput( inputId = 'refresh_helper', value = 0,label="" ) ),
-    
+
     actionButton("reset", "Reset Values"),
     actionButton("submit", "Update Plot"),
     fluidRow(
       column(
         2,
         wellPanel(
-          # <br/> <br/> # to make line up if we get other side to do an extra line
-            textInput("bracket1T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "0"),
+          textInput("bracket1T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "0"),
 
-            textInput("bracket2T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "2"),
-
-          
-            textInput("bracket3T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "2"),
-
-          
-            textInput("bracket4T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3"),
+          textInput("bracket2T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "2"),
 
 
-          
+          textInput("bracket3T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "2"),
 
-          uiOutput("myui")),
+
+          textInput("bracket4T", label = HTML("Apply a tax of (%): <br/> <br/>"), value = "3"),
+
+
+
+
+          uiOutput("myui")
+        ),
 
 
 
@@ -48,32 +47,29 @@ ui <-
         tags$a(href = "https://sastoudt.github.io", "Sara Stoudt"),
         h6(""),
         h6("This visualization is part of an Open Policy Analysis which follows the guidelines of the"),
-tags$a(href="https://www.bitss.org/opa/","Berkeley Initiative for Transparency in the Social Sciences."),
-h6(""),
-tags$a(href="https://github.com/fhoces/opa-wealthtax/blob/master/credits.md", "See all the collaborators here.")#,
-
+        tags$a(href = "https://www.bitss.org/opa/", "Berkeley Initiative for Transparency in the Social Sciences."),
+        h6(""),
+        tags$a(href = "https://github.com/fhoces/opa-wealthtax/blob/master/credits.md", "See all the collaborators here.") # ,
       ),
       column(
         2,
         wellPanel(
-          
-            textInput("bracketV1T", label = "to wealth above ($m):", value = "10"),
-          
+          textInput("bracketV1T", label = "to wealth above ($m):", value = "10"),
 
 
-          
-            textInput("bracketV2T", label = "to wealth above ($m):", value = "50"),
-         
-            textInput("bracketV3T", label = "to wealth above ($m):", value = "500"),
 
 
-          
-            textInput("bracketV4T", label = "to wealth above ($m):", value = "1000"),
-         
+          textInput("bracketV2T", label = "to wealth above ($m):", value = "50"),
 
-         
-            uiOutput("myui2")
-          
+          textInput("bracketV3T", label = "to wealth above ($m):", value = "500"),
+
+
+
+          textInput("bracketV4T", label = "to wealth above ($m):", value = "1000"),
+
+
+
+          uiOutput("myui2")
         ),
         h6("Assisted by:"),
         h6(""),
@@ -82,8 +78,8 @@ tags$a(href="https://github.com/fhoces/opa-wealthtax/blob/master/credits.md", "S
 
         h6("Deployment help by:"),
         h6("Akcan Balkir"),
-        tags$a(href="https://mybinder.readthedocs.io/en/latest/", "and the Binder Team"),
- 
+        tags$a(href = "https://mybinder.readthedocs.io/en/latest/", "and the Binder Team"),
+
         h6(""),
         tags$a(href = "https://www.splitwise.com/taxes/#/brackets/0|160|353|432|479|543/10.1|14.9|25.0|28.1|33#.0|35.1/params/1|1|1|0|1|15", "Inspired by this visualization")
       ),


### PR DESCRIPTION
- only update text boxes if give the same bracket twice
- just order brackets before computing instead of updating ui, allow for non-monotone tax rates
- update to percentile for families affected

Still working on refreshing plot upon "refresh" instead of needing an additional "recalculate".